### PR TITLE
Fix a bug where oxtrust IP would not be updated

### DIFF
--- a/scripts/entrypoint.py
+++ b/scripts/entrypoint.py
@@ -235,6 +235,8 @@ def main():
 
             if current_ip_in_ldap in oxtrust_ip_pool and is_cr_enabled:
                 write_master_ip(current_ip_in_ldap)
+            else:
+                signalon = True
 
             if check_master_ip(current_ip_in_ldap) and oxtrust_containers:
                 signalon = True


### PR DESCRIPTION
When tearing down a docker stack with `./pygluu-compose down` and then turning it back up with `./pygluu-compose up`, the `cr-rotate` container would not update the oxtrust IP unless you went into the web UI and put in either the **SIGNAL_IP** or **DEFAULT_IP**.  This was caused by `signalon` not being set to true when the current IP was not in the list of oxtrust servers, which prevented these lines from evaluating as `True`:

https://github.com/GluuFederation/docker-cr-rotate/blob/4.2/scripts/entrypoint.py#L267-L268